### PR TITLE
Primary/ secondary icon resizing to any dimension inside GtkEntry from a...

### DIFF
--- a/gtk/gtkentry.h
+++ b/gtk/gtkentry.h
@@ -265,7 +265,13 @@ void           gtk_entry_set_placeholder_text    (GtkEntry             *entry,
 GDK_AVAILABLE_IN_ALL
 void           gtk_entry_set_icon_from_pixbuf            (GtkEntry             *entry,
 							  GtkEntryIconPosition  icon_pos,
-							  GdkPixbuf            *pixbuf);
+							  GdkPixbuf            *pixbuf );
+                                                          
+void           gtk_entry_set_icon_from_pixbuf_at_size  (GtkEntry              *entry,
+							GtkEntryIconPosition  icon_pos,
+							GdkPixbuf             *pixbuf ,
+                                                        GtkIconSize           icon_size);
+
 GDK_DEPRECATED_IN_3_10_FOR(gtk_entry_set_icon_from_icon_name)
 void           gtk_entry_set_icon_from_stock             (GtkEntry             *entry,
 							  GtkEntryIconPosition  icon_pos,


### PR DESCRIPTION
...pplication

GtkEntry is a widget used in GTK+ to write text .Icons can be placed at the start and end of GtkEntry . In GtkEntry , only fixed size icon of dimension 16 x 16 can be placed . But applications developer may require to change the icon size according to the size of GtkEntry .  This is not possible in latest release of GTK+ . Due to this there is lot of size difference between icon and GtkEntry which does not look good if the size of GtkEntry is much bigger than the size of icon.

In this patch I provided  new feature enhancement in  GtkEntry to resize the icon  . This feature or interface 
( gtk_entry_set_icon_from_pixbuf_at_size)allows application developers to change the icon size to any desired dimension from the application source code . 

This allows better look and feel of GtkEntry bar.
