### PR TITLE
Fix monitors enumeration bug

### DIFF
--- a/gdk/win32/gdkdisplay-win32.c
+++ b/gdk/win32/gdkdisplay-win32.c
@@ -83,7 +83,7 @@ enum_monitor (HMONITOR hmonitor,
 
   monitor = _gdk_monitors + *index;
 
-  monitor_info.cbSize = sizeof (MONITORINFOEX);
+  monitor_info.cbSize = sizeof (MONITORINFOEXA2);
   GetMonitorInfoA (hmonitor, (MONITORINFO *) &monitor_info);
 
 #ifndef MONITORINFOF_PRIMARY


### PR DESCRIPTION
Fix monitors enumeration bug. By default used MONITORINFOEXW (UTF-16 Build) with wrong structure size
