### PR TITLE
Fix spelling of occure* in various files.

### DIFF
--- a/README.in
+++ b/README.in
@@ -53,7 +53,7 @@ In the bug report please include:
   of software that can be downloaded.
 
 * If the bug was a crash, the exact text that was printed out
-  when the crash occured.
+  when the crash occurred.
 
 * Further information such as stack traces may be useful, but
   is not necessary.

--- a/gdk/win32/gdkwindow-win32.c
+++ b/gdk/win32/gdkwindow-win32.c
@@ -2618,7 +2618,7 @@ gdk_win32_window_begin_resize_drag (GdkWindow     *window,
   if (button != 1)
     return;
   
-  /* Must break the automatic grab that occured when the button was
+  /* Must break the automatic grab that occurred when the button was
    * pressed, otherwise it won't work.
    */
   gdk_device_ungrab (device, 0);
@@ -2685,7 +2685,7 @@ gdk_win32_window_begin_move_drag (GdkWindow *window,
   if (button != 1)
     return;
   
-  /* Must break the automatic grab that occured when the button was pressed,
+  /* Must break the automatic grab that occurred when the button was pressed,
    * otherwise it won't work.
    */
   gdk_device_ungrab (device, 0);

--- a/gtk/compose-parse.py
+++ b/gtk/compose-parse.py
@@ -811,9 +811,9 @@ if opt_gtk:
 	ct_index = start_offset
 	for line_num in range(len(compose_table)):
 		for i in range(WIDTHOFCOMPOSETABLE):
-			occurences = compose_table[line_num][i+1]
+			occurrences = compose_table[line_num][i+1]
 			compose_table[line_num][i+1] = ct_index
-			ct_index += occurences * (i+2)
+			ct_index += occurrences * (i+2)
 
 	for sequence in xorg_compose_sequences:
 		ct_second_part.append(map(convert_UnotationToHex, sequence))

--- a/gtk/gtkcssprovider.c
+++ b/gtk/gtkcssprovider.c
@@ -1284,7 +1284,7 @@ gtk_css_provider_class_init (GtkCssProviderClass *klass)
    * @section: section the error happened in
    * @error: The parsing error
    *
-   * Signals that a parsing error occured. the @path, @line and @position
+   * Signals that a parsing error occurred. the @path, @line and @position
    * describe the actual location of the error as accurately as possible.
    *
    * Parsing errors are never fatal, so the parsing will resume after
@@ -2771,7 +2771,7 @@ gtk_css_provider_load_internal (GtkCssProvider *css_provider,
  *
  * Returns: %TRUE. The return value is deprecated and %FALSE will only be
  *     returned for backwards compatibility reasons if an @error is not 
- *     %NULL and a loading error occured. To track errors while loading
+ *     %NULL and a loading error occurred. To track errors while loading
  *     CSS, connect to the #GtkCssProvider::parsing-error signal.
  **/
 gboolean
@@ -2819,7 +2819,7 @@ gtk_css_provider_load_from_data (GtkCssProvider  *css_provider,
  *
  * Returns: %TRUE. The return value is deprecated and %FALSE will only be
  *     returned for backwards compatibility reasons if an @error is not 
- *     %NULL and a loading error occured. To track errors while loading
+ *     %NULL and a loading error occurred. To track errors while loading
  *     CSS, connect to the #GtkCssProvider::parsing-error signal.
  **/
 gboolean
@@ -2852,7 +2852,7 @@ gtk_css_provider_load_from_file (GtkCssProvider  *css_provider,
  *
  * Returns: %TRUE. The return value is deprecated and %FALSE will only be
  *     returned for backwards compatibility reasons if an @error is not 
- *     %NULL and a loading error occured. To track errors while loading
+ *     %NULL and a loading error occurred. To track errors while loading
  *     CSS, connect to the #GtkCssProvider::parsing-error signal.
  **/
 gboolean

--- a/gtk/gtkplacessidebar.c
+++ b/gtk/gtkplacessidebar.c
@@ -164,7 +164,7 @@ struct _GtkPlacesSidebar {
 
   guint mounting               : 1;
   guint  drag_data_received    : 1;
-  guint drop_occured           : 1;
+  guint drop_occurred          : 1;
   guint show_desktop_set       : 1;
   guint show_desktop           : 1;
   guint show_connect_to_server : 1;
@@ -1982,7 +1982,7 @@ drag_data_received_callback (GtkWidget        *widget,
 
   g_signal_stop_emission_by_name (widget, "drag-data-received");
 
-  if (!sidebar->drop_occured)
+  if (!sidebar->drop_occurred)
     return;
 
   /* Compute position */
@@ -2096,7 +2096,7 @@ drag_data_received_callback (GtkWidget        *widget,
     }
 
 out:
-  sidebar->drop_occured = FALSE;
+  sidebar->drop_occurred = FALSE;
   free_drag_data (sidebar);
   remove_drop_bookmark_feedback_row (sidebar);
   gtk_drag_finish (context, success, FALSE, time);
@@ -2114,7 +2114,7 @@ drag_drop_callback (GtkTreeView      *tree_view,
 {
   gboolean retval = FALSE;
 
-  sidebar->drop_occured = TRUE;
+  sidebar->drop_occurred = TRUE;
   retval = get_drag_data (tree_view, context, time);
   g_signal_stop_emission_by_name (tree_view, "drag-drop");
   return retval;

--- a/gtk/gtkprintoperation.h
+++ b/gtk/gtkprintoperation.h
@@ -81,7 +81,7 @@ typedef enum {
 
 /**
  * GtkPrintOperationResult:
- * @GTK_PRINT_OPERATION_RESULT_ERROR: An error has occured.
+ * @GTK_PRINT_OPERATION_RESULT_ERROR: An error has occurred.
  * @GTK_PRINT_OPERATION_RESULT_APPLY: The print settings should be stored.
  * @GTK_PRINT_OPERATION_RESULT_CANCEL: The print operation has been canceled,
  *     the print settings should not be stored.

--- a/gtk/gtktextbuffer.c
+++ b/gtk/gtktextbuffer.c
@@ -3804,7 +3804,7 @@ gtk_text_buffer_paste_clipboard (GtkTextBuffer *buffer,
   /* When pasting with the cursor inside the selection area, you
    * replace the selection with the new text, otherwise, you
    * simply insert the new text at the point where the click
-   * occured, unselecting any selected text. The replace_selection
+   * occurred, unselecting any selected text. The replace_selection
    * flag toggles this behavior.
    */
   data->replace_selection = FALSE;

--- a/gtk/gtktexttag.c
+++ b/gtk/gtktexttag.c
@@ -775,7 +775,7 @@ gtk_text_tag_class_init (GtkTextTagClass *klass)
    * @tag: the #GtkTextTag on which the signal is emitted
    * @object: the object the event was fired from (typically a #GtkTextView)
    * @event: the event which triggered the signal
-   * @iter: a #GtkTextIter pointing at the location the event occured
+   * @iter: a #GtkTextIter pointing at the location the event occurred
    *
    * The ::event signal is emitted when an event occurs on a region of the
    * buffer marked with this tag.

--- a/m4macros/gtk-3.0.m4
+++ b/m4macros/gtk-3.0.m4
@@ -181,7 +181,7 @@ main ()
           echo "*** If you have an old version installed, it is best to remove it, although"
           echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH" ],
         [ echo "*** The test program failed to compile or link. See the file config.log for the"
-          echo "*** exact error that occured. This usually means GTK+ is incorrectly installed."])
+          echo "*** exact error that occurred. This usually means GTK+ is incorrectly installed."])
           CFLAGS="$ac_save_CFLAGS"
           LIBS="$ac_save_LIBS"
        fi


### PR DESCRIPTION
Fix spelling of "occured"/"occurence" in various places; mostly in comments, but also in some variable names. The variables would seem to be local.
