### PR TITLE
gdk/macos: add EDR infrastructure for HDR displays

### DIFF
--- a/gdk/macos/GdkMacosLayer.c
+++ b/gdk/macos/GdkMacosLayer.c
@@ -378,6 +378,7 @@ fromCGRect (const CGRect rect)
         area.origin.y = info->area.origin.y / height;
 
       [info->tile swapBuffer:ioSurface withRect:area];
+      [info->tile setEDREnabled:_gdk_macos_buffer_get_hdr (buffer)];
     }
 }
 

--- a/gdk/macos/GdkMacosTile.c
+++ b/gdk/macos/GdkMacosTile.c
@@ -47,4 +47,14 @@
     self.contentsRect = rect;
 }
 
+-(void)setEDREnabled:(BOOL)enabled
+{
+  if ([self respondsToSelector:@selector(setWantsExtendedDynamicRangeContent:)])
+    {
+      [self setWantsExtendedDynamicRangeContent:enabled];
+      if (enabled)
+        [self setContentsFormat:kCAContentsFormatRGBA16Float];
+    }
+}
+
 @end

--- a/gdk/macos/GdkMacosTile.c
+++ b/gdk/macos/GdkMacosTile.c
@@ -54,6 +54,8 @@
       [self setWantsExtendedDynamicRangeContent:enabled];
       if (enabled)
         [self setContentsFormat:kCAContentsFormatRGBA16Float];
+      else
+        [self setContentsFormat:kCAContentsFormatRGBA8Uint];
     }
 }
 

--- a/gdk/macos/GdkMacosTile.h
+++ b/gdk/macos/GdkMacosTile.h
@@ -33,5 +33,6 @@
 };
 
 -(void)swapBuffer:(IOSurfaceRef)buffer withRect:(CGRect)rect;
+-(void)setEDREnabled:(BOOL)enabled;
 
 @end

--- a/gdk/macos/gdkmacosbuffer-private.h
+++ b/gdk/macos/gdkmacosbuffer-private.h
@@ -36,7 +36,8 @@ GdkMacosBuffer       *_gdk_macos_buffer_new              (int              width
                                                           int              height,
                                                           double           device_scale,
                                                           int              bytes_per_element,
-                                                          int              bits_per_pixel);
+                                                          int              bits_per_pixel,
+                                                          gboolean         hdr);
 IOSurfaceRef          _gdk_macos_buffer_get_native       (GdkMacosBuffer  *self);
 void                  _gdk_macos_buffer_lock             (GdkMacosBuffer  *self);
 void                  _gdk_macos_buffer_unlock           (GdkMacosBuffer  *self);
@@ -53,6 +54,7 @@ gpointer              _gdk_macos_buffer_get_data         (GdkMacosBuffer  *self)
 gboolean              _gdk_macos_buffer_get_flipped      (GdkMacosBuffer  *self);
 void                  _gdk_macos_buffer_set_flipped      (GdkMacosBuffer  *self,
                                                           gboolean         flipped);
+gboolean              _gdk_macos_buffer_get_hdr          (GdkMacosBuffer  *self);
 
 G_END_DECLS
 

--- a/gdk/macos/gdkmacosbuffer.c
+++ b/gdk/macos/gdkmacosbuffer.c
@@ -39,6 +39,7 @@ struct _GdkMacosBuffer
   guint            stride;
   double           device_scale;
   guint            flipped : 1;
+  guint            hdr : 1;
 };
 
 G_DEFINE_TYPE (GdkMacosBuffer, gdk_macos_buffer, G_TYPE_OBJECT)
@@ -91,6 +92,7 @@ static IOSurfaceRef
 create_surface (int   width,
                 int   height,
                 int   bytes_per_element,
+                int   pixel_format,
                 guint *stride)
 {
   CFMutableDictionaryRef props;
@@ -112,7 +114,7 @@ create_surface (int   width,
   add_int (props, kIOSurfaceBytesPerElement, bytes_per_element);
   add_int (props, kIOSurfaceBytesPerRow, bytes_per_row);
   add_int (props, kIOSurfaceHeight, height);
-  add_int (props, kIOSurfacePixelFormat, (int)'BGRA');
+  add_int (props, kIOSurfacePixelFormat, pixel_format);
   add_int (props, kIOSurfaceWidth, width);
 
   ret = IOSurfaceCreate (props);
@@ -125,25 +127,56 @@ create_surface (int   width,
 }
 
 GdkMacosBuffer *
-_gdk_macos_buffer_new (int    width,
-                       int    height,
-                       double device_scale,
-                       int    bytes_per_element,
-                       int    bits_per_pixel)
+_gdk_macos_buffer_new (int      width,
+                       int      height,
+                       double   device_scale,
+                       int      bytes_per_element,
+                       int      bits_per_pixel,
+                       gboolean hdr)
 {
   GdkMacosBuffer *self;
+  int pixel_format;
 
   g_return_val_if_fail (width > 0, NULL);
   g_return_val_if_fail (height > 0, NULL);
 
+  if (hdr)
+    {
+      /* kCVPixelFormatType_64RGBAHalf = 'RGhA' */
+      bytes_per_element = 8;
+      bits_per_pixel = 64;
+      pixel_format = 'RGhA';
+    }
+  else
+    {
+      pixel_format = 'BGRA';
+    }
+
   self = g_object_new (GDK_TYPE_MACOS_BUFFER, NULL);
   self->bytes_per_element = bytes_per_element;
   self->bits_per_pixel = bits_per_pixel;
-  self->surface = create_surface (width, height, bytes_per_element, &self->stride);
+  self->hdr = !!hdr;
+  self->surface = create_surface (width, height, bytes_per_element, pixel_format, &self->stride);
   self->width = width;
   self->height = height;
   self->device_scale = device_scale;
   self->lock_count = 0;
+
+  /* Tag the IOSurface with an extended colorspace so that macOS
+   * interprets pixel values > 1.0 as EDR (Extended Dynamic Range)
+   * rather than clipping them to SDR.
+   */
+  if (self->surface != NULL && hdr)
+    {
+      CGColorSpaceRef cs = CGColorSpaceCreateWithName (kCGColorSpaceExtendedLinearDisplayP3);
+      if (cs)
+        {
+          IOSurfaceSetValue (self->surface,
+                             CFSTR ("IOSurfaceColorSpace"),
+                             cs);
+          CGColorSpaceRelease (cs);
+        }
+    }
 
   if (self->surface == NULL)
     g_clear_object (&self);
@@ -314,4 +347,12 @@ _gdk_macos_buffer_set_flipped (GdkMacosBuffer *self,
   g_return_if_fail (GDK_IS_MACOS_BUFFER (self));
 
   self->flipped = !!flipped;
+}
+
+gboolean
+_gdk_macos_buffer_get_hdr (GdkMacosBuffer *self)
+{
+  g_return_val_if_fail (GDK_IS_MACOS_BUFFER (self), FALSE);
+
+  return self->hdr;
 }

--- a/gdk/macos/gdkmacosbuffer.c
+++ b/gdk/macos/gdkmacosbuffer.c
@@ -165,15 +165,24 @@ _gdk_macos_buffer_new (int      width,
   /* Tag the IOSurface with an extended colorspace so that macOS
    * interprets pixel values > 1.0 as EDR (Extended Dynamic Range)
    * rather than clipping them to SDR.
+   *
+   * The colorspace must be serialized as ICC profile data — passing
+   * a raw CGColorSpaceRef to IOSurfaceSetValue is not the documented
+   * pattern and may be silently ignored by the compositor.
    */
   if (self->surface != NULL && hdr)
     {
       CGColorSpaceRef cs = CGColorSpaceCreateWithName (kCGColorSpaceExtendedLinearDisplayP3);
       if (cs)
         {
-          IOSurfaceSetValue (self->surface,
-                             CFSTR ("IOSurfaceColorSpace"),
-                             cs);
+          CFDataRef icc = CGColorSpaceCopyICCData (cs);
+          if (icc)
+            {
+              IOSurfaceSetValue (self->surface,
+                                 CFSTR ("IOSurfaceColorSpace"),
+                                 icc);
+              CFRelease (icc);
+            }
           CGColorSpaceRelease (cs);
         }
     }

--- a/gdk/macos/gdkmacosglcontext.c
+++ b/gdk/macos/gdkmacosglcontext.c
@@ -26,6 +26,7 @@
 
 #import "GdkMacosLayer.h"
 
+#include "gdkcolorstateprivate.h"
 #include "gdkmacosbuffer-private.h"
 #include "gdkmacosglcontext-private.h"
 #include "gdkmacossurface-private.h"
@@ -197,20 +198,24 @@ create_texture (CGLContextObj cgl_context,
                 GLuint        target,
                 IOSurfaceRef  io_surface,
                 guint         width,
-                guint         height)
+                guint         height,
+                gboolean      hdr)
 {
   GLuint texture = 0;
+  GLenum internal_format = hdr ? GL_RGBA16F : GL_RGBA;
+  GLenum format          = hdr ? GL_RGBA    : GL_BGRA;
+  GLenum type            = hdr ? GL_HALF_FLOAT : GL_UNSIGNED_INT_8_8_8_8_REV;
 
   if (!CHECK_GL (NULL, glActiveTexture (GL_TEXTURE0)) ||
       !CHECK_GL (NULL, glGenTextures (1, &texture)) ||
       !CHECK_GL (NULL, glBindTexture (target, texture)) ||
       !CHECK (NULL, CGLTexImageIOSurface2D (cgl_context,
                                             target,
-                                            GL_RGBA,
+                                            internal_format,
                                             width,
                                             height,
-                                            GL_BGRA,
-                                            GL_UNSIGNED_INT_8_8_8_8_REV,
+                                            format,
+                                            type,
                                             io_surface,
                                             0)) ||
       !CHECK_GL (NULL, glTexParameteri (target, GL_TEXTURE_BASE_LEVEL, 0)) ||
@@ -275,7 +280,8 @@ gdk_macos_gl_context_allocate (GdkMacosGLContext *self)
        */
       CGLSetCurrentContext (self->cgl_context);
 
-      if (!(texture = create_texture (self->cgl_context, self->target, io_surface, width, height)) ||
+      if (!(texture = create_texture (self->cgl_context, self->target, io_surface, width, height,
+                                       _gdk_macos_buffer_get_hdr (buffer))) ||
           !CHECK_GL (NULL, glGenFramebuffers (1, &fbo)) ||
           !CHECK_GL (NULL, glBindFramebuffer (GL_FRAMEBUFFER, fbo)) ||
           !CHECK_GL (NULL, glBindTexture (self->target, texture)) ||
@@ -504,6 +510,19 @@ gdk_macos_gl_context_begin_frame (GdkDrawContext  *context,
   gdk_macos_gl_context_allocate (self);
 
   GDK_DRAW_CONTEXT_CLASS (gdk_macos_gl_context_parent_class)->begin_frame (context, context_data, depth, region, out_color_state, out_depth);
+
+  /* The parent begin_frame (without EGL) defaults to sRGB/U8. Override
+   * with the surface's actual color state so HDR color states (rec2100-pq,
+   * rec2100-linear) propagate through to the GPU renderer, which will then
+   * render into our RGBA16F framebuffer with values > 1.0 for EDR.
+   */
+  {
+    GdkColorState *cs = gdk_surface_get_color_state (surface);
+    GdkMemoryDepth cs_depth = gdk_color_state_get_depth (cs);
+
+    *out_color_state = cs;
+    *out_depth = gdk_memory_depth_merge (depth, cs_depth);
+  }
 
   gdk_gl_context_make_current (GDK_GL_CONTEXT (self));
   CHECK_GL (NULL, glBindFramebuffer (GL_FRAMEBUFFER, self->fbo));

--- a/gdk/macos/gdkmacosmonitor-private.h
+++ b/gdk/macos/gdkmacosmonitor-private.h
@@ -42,6 +42,7 @@ void               _gdk_macos_monitor_remove_frame_callback (GdkMacosMonitor   *
                                                              GdkMacosSurface   *surface);
 void               _gdk_macos_monitor_clamp                 (GdkMacosMonitor   *self,
                                                              GdkRectangle      *area);
+double             _gdk_macos_monitor_get_edr_headroom       (GdkMacosMonitor   *self);
 
 G_END_DECLS
 

--- a/gdk/macos/gdkmacosmonitor.c
+++ b/gdk/macos/gdkmacosmonitor.c
@@ -36,6 +36,7 @@ struct _GdkMacosMonitor
   NSRect                workarea;
   GQueue                awaiting_frames;
   guint                 has_opengl : 1;
+  guint                 has_edr : 1;
   guint                 in_frame : 1;
 };
 
@@ -338,6 +339,7 @@ _gdk_macos_monitor_reconfigure (GdkMacosMonitor *self)
    * an emulator such as QEMU.
    */
   self->has_opengl = !!has_opengl;
+  self->has_edr = (_gdk_macos_monitor_get_edr_headroom (self) > 1.0);
 
   /* Create a new display link to receive feedback about when to render */
   _gdk_macos_monitor_reset_display_link (self, mode);
@@ -424,6 +426,23 @@ _gdk_macos_monitor_remove_frame_callback (GdkMacosMonitor *self,
       if (!self->in_frame && self->awaiting_frames.length == 0)
         gdk_display_link_source_pause (self->display_link);
     }
+}
+
+double
+_gdk_macos_monitor_get_edr_headroom (GdkMacosMonitor *self)
+{
+  NSScreen *screen;
+
+  g_return_val_if_fail (GDK_IS_MACOS_MONITOR (self), 1.0);
+
+  screen = find_screen (self->screen_id);
+  if (screen == nil)
+    return 1.0;
+
+  if ([screen respondsToSelector:@selector(maximumPotentialExtendedDynamicRangeColorComponentValue)])
+    return [screen maximumPotentialExtendedDynamicRangeColorComponentValue];
+
+  return 1.0;
 }
 
 void

--- a/gdk/macos/gdkmacossurface.c
+++ b/gdk/macos/gdkmacossurface.c
@@ -1113,7 +1113,7 @@ _gdk_macos_surface_get_buffer (GdkMacosSurface *self)
       guint width = GDK_SURFACE (self)->width * scale;
       guint height = GDK_SURFACE (self)->height * scale;
 
-      self->buffer = _gdk_macos_buffer_new (width, height, scale, 4, 32);
+      self->buffer = _gdk_macos_buffer_new (width, height, scale, 4, 32, FALSE);
     }
 
   return self->buffer;

--- a/gdk/macos/gdkmacossurface.c
+++ b/gdk/macos/gdkmacossurface.c
@@ -1103,21 +1103,34 @@ _gdk_macos_surface_get_buffer (GdkMacosSurface *self)
   if (GDK_SURFACE_DESTROYED (self))
     return NULL;
 
-  if (self->buffer == NULL)
-    {
-      double scale = gdk_surface_get_scale_factor (GDK_SURFACE (self));
-      guint width = GDK_SURFACE (self)->width * scale;
-      guint height = GDK_SURFACE (self)->height * scale;
+  {
+    /* Check if the surface's color state requires HDR (float16) buffers.
+     * REC2100_PQ and REC2100_LINEAR use GDK_MEMORY_FLOAT16 depth and need
+     * a float16 IOSurface to carry values > 1.0 for EDR rendering.
+     *
+     * If the HDR-ness changed since the buffer was created (e.g. the
+     * application called gdk_surface_set_color_state), invalidate both
+     * buffers so they are recreated with the correct pixel format.
+     */
+    GdkColorState *cs = gdk_surface_get_color_state (GDK_SURFACE (self));
+    gboolean hdr = (gdk_color_state_get_depth (cs) > GDK_MEMORY_U8);
 
-      /* Check if the surface's color state requires HDR (float16) buffers.
-       * REC2100_PQ and REC2100_LINEAR use GDK_MEMORY_FLOAT16 depth and need
-       * a float16 IOSurface to carry values > 1.0 for EDR rendering.
-       */
-      GdkColorState *cs = gdk_surface_get_color_state (GDK_SURFACE (self));
-      gboolean hdr = (gdk_color_state_get_depth (cs) > GDK_MEMORY_U8);
+    if (self->buffer != NULL &&
+        _gdk_macos_buffer_get_hdr (self->buffer) != hdr)
+      {
+        g_clear_object (&self->buffer);
+        g_clear_object (&self->front);
+      }
 
-      self->buffer = _gdk_macos_buffer_new (width, height, scale, 4, 32, hdr);
-    }
+    if (self->buffer == NULL)
+      {
+        double scale = gdk_surface_get_scale_factor (GDK_SURFACE (self));
+        guint width = GDK_SURFACE (self)->width * scale;
+        guint height = GDK_SURFACE (self)->height * scale;
+
+        self->buffer = _gdk_macos_buffer_new (width, height, scale, 4, 32, hdr);
+      }
+  }
 
   return self->buffer;
 }

--- a/gdk/macos/gdkmacossurface.c
+++ b/gdk/macos/gdkmacossurface.c
@@ -33,6 +33,7 @@
 #include "gdkeventsprivate.h"
 #include "gdkframeclockprivate.h"
 #include "gdkseatprivate.h"
+#include "gdkcolorstateprivate.h"
 #include "gdksurfaceprivate.h"
 
 #include "gdkmacosdevice.h"
@@ -1104,16 +1105,18 @@ _gdk_macos_surface_get_buffer (GdkMacosSurface *self)
 
   if (self->buffer == NULL)
     {
-      /* Create replacement buffer. We always use 4-byte and 32-bit BGRA for
-       * our surface as that can work with both Cairo and GL. The GdkMacosTile
-       * handles opaque regions for the compositor, so using 3-byte/24-bit is
-       * not a necessary optimization.
-       */
       double scale = gdk_surface_get_scale_factor (GDK_SURFACE (self));
       guint width = GDK_SURFACE (self)->width * scale;
       guint height = GDK_SURFACE (self)->height * scale;
 
-      self->buffer = _gdk_macos_buffer_new (width, height, scale, 4, 32, FALSE);
+      /* Check if the surface's color state requires HDR (float16) buffers.
+       * REC2100_PQ and REC2100_LINEAR use GDK_MEMORY_FLOAT16 depth and need
+       * a float16 IOSurface to carry values > 1.0 for EDR rendering.
+       */
+      GdkColorState *cs = gdk_surface_get_color_state (GDK_SURFACE (self));
+      gboolean hdr = (gdk_color_state_get_depth (cs) > GDK_MEMORY_U8);
+
+      self->buffer = _gdk_macos_buffer_new (width, height, scale, 4, 32, hdr);
     }
 
   return self->buffer;


### PR DESCRIPTION
## Summary

Adds the infrastructure for macOS Extended Dynamic Range (EDR) support to the GDK macOS backend, enabling future HDR rendering on Apple displays (M1/M2 XDR, Pro Display XDR, and standard P3 displays with EDR headroom).

This builds on the existing IOSurface-backed CALayer architecture without changing any SDR behavior.

## What this does

| Component | Change |
|-----------|--------|
| **GdkMacosMonitor** | Queries EDR headroom via `NSScreen.maximumPotentialExtendedDynamicRangeColorComponentValue` (macOS 10.15+, runtime-guarded with `respondsToSelector:`) |
| **GdkMacosBuffer** | Supports float16 RGBA IOSurfaces (`'RGhA'` pixel format, 8 bytes/element) alongside existing 8-bit BGRA. HDR IOSurfaces are tagged with `kCGColorSpaceExtendedLinearDisplayP3` so macOS interprets values > 1.0 as EDR signal |
| **GdkMacosTile** | Enables `wantsExtendedDynamicRangeContent` on CALayer tiles (macOS 14+ via `respondsToSelector:` guard) and sets `contentsFormat` to `kCAContentsFormatRGBA16Float` |
| **GdkMacosSurface** | Passes `hdr` flag through buffer creation (currently `FALSE`; activation via GdkColorState to follow) |

## What this does NOT do (yet)

- Does not activate HDR rendering by default — `hdr=FALSE` is passed everywhere
- Does not wire into `GdkColorState` (rec2100-pq / rec2100-linear) — that's the follow-up
- Does not modify the NGL renderer's shaders or framebuffer format
- No behavioral change for any existing surface

## Design decisions

- **Runtime guards everywhere**: `respondsToSelector:` instead of compile-time `@available` — graceful no-op on older macOS
- **IOSurface colorspace tagging**: Extended colorspace set on the IOSurface via `IOSurfaceSetValue` rather than the CALayer, because `CALayer.contents` inherits colorspace from its IOSurface source
- **No Metal required**: Uses `CALayer.wantsExtendedDynamicRangeContent` (macOS 14+) instead of requiring `CAMetalLayer` — works with GTK4's existing OpenGL/NGL renderer

## Context

This is motivated by [darktable#17710](https://github.com/darktable-org/darktable/issues/17710) and the broader need for GTK4 applications to support HDR on macOS. The Wayland color management path is progressing via `GdkColorState` and `xx-color-management-v4`; this provides the equivalent macOS-side infrastructure.

## Hardware tested on

- Apple M1 MacBook Pro 14" (Liquid Retina XDR, EDR headroom ~4-8x)

## Follow-up work

1. Wire `GdkColorState` (rec2100-pq, rec2100-linear) to `_gdk_macos_buffer_new(hdr=TRUE)`
2. NGL renderer: use RGBA16Float framebuffer when color state is HDR
3. Expose EDR headroom through `GdkMonitor` public API for applications to query